### PR TITLE
✨(oidc) allow JSON format in user info endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(oidc) allow JSON format in user info endpoint #5
+
 ## [0.0.2] - 2025-04-07
 
 ### Fixed

--- a/documentation/how-to-use-oidc-backend.md
+++ b/documentation/how-to-use-oidc-backend.md
@@ -28,6 +28,7 @@ OIDC_RP_CLIENT_SECRET = "your-client-secret"
 OIDC_OP_TOKEN_ENDPOINT = "https://your-provider.com/token"
 OIDC_OP_USER_ENDPOINT = "https://your-provider.com/userinfo"
 OIDC_OP_LOGOUT_ENDPOINT = "https://your-provider.com/logout"
+OIDC_OP_USER_ENDPOINT_FORMAT = "AUTO"  # AUTO, JSON, or JWT
 
 # Optional settings
 OIDC_USER_SUB_FIELD = "sub"  # Field to store the OIDC subject identifier, defaults to "sub"

--- a/documentation/how-to-use-oidc-resource-server-backend.md
+++ b/documentation/how-to-use-oidc-resource-server-backend.md
@@ -44,6 +44,7 @@ OIDC_RP_CLIENT_SECRET = "your-client-secret"
 # Authorization server endpoints
 OIDC_OP_TOKEN_ENDPOINT = "https://your-provider.com/token"
 OIDC_OP_USER_ENDPOINT = "https://your-provider.com/userinfo"
+OIDC_OP_USER_ENDPOINT_FORMAT = "AUTO"  # AUTO, JSON, or JWT
 ```
 
 ### URLs Configuration

--- a/src/lasuite/oidc_login/enums.py
+++ b/src/lasuite/oidc_login/enums.py
@@ -1,0 +1,12 @@
+"""Enum for OIDC login."""
+
+from enum import StrEnum
+
+
+# OIDC_OP_USER_ENDPOINT allowed values
+class OIDCUserEndpointFormat(StrEnum):
+    """Enum for OIDC OP User Endpoint."""
+
+    JWT = "jwt"
+    JSON = "json"
+    AUTO = "auto"


### PR DESCRIPTION
## Purpose

In some cases, the OIDC identity provider does not allow to use JWT in userinfo response, we want to be able to explicitely disable it.


## Proposal

- [x] add `OIDC_OP_USER_ENDPOINT_FORMAT` to explicitly tell what is the format expected for the userinfo endpoint or let the code detect it from the content type.
