### PR TITLE
✨(oidc) disable duplicated emails for users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - ✨(oidc) allow JSON format in user info endpoint #5
 - ✨(oidc) add essential claims check setting #6
+- ✨(oidc) disable duplicated emails for users #7
 
 ## [0.0.2] - 2025-04-07
 

--- a/documentation/how-to-use-oidc-backend.md
+++ b/documentation/how-to-use-oidc-backend.md
@@ -35,6 +35,7 @@ OIDC_USER_SUB_FIELD = "sub"  # Field to store the OIDC subject identifier, defau
 USER_OIDC_FIELDS_TO_FULLNAME = ["first_name", "last_name"]  # Fields used to compute user's full name
 USER_OIDC_ESSENTIAL_CLAIMS = ["sub", "last_name"]  # Claims required for user identification
 OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = True  # Allow fallback to email for user identification
+OIDC_ALLOW_DUPLICATE_EMAILS = True  # Allow duplicate emails in the system
 OIDC_CREATE_USER = True  # Automatically create users if they don't exist
 ALLOW_LOGOUT_GET_METHOD = True  # Allow GET method for logout
 ```

--- a/src/lasuite/oidc_login/exceptions.py
+++ b/src/lasuite/oidc_login/exceptions.py
@@ -1,0 +1,11 @@
+"""Exceptions for the OIDC login module."""
+
+
+class DuplicateEmailError(Exception):
+    """Raised when an email is already associated with a pre-existing user."""
+
+    def __init__(self, message=None, email=None):
+        """Set message and email to describe the exception."""
+        self.message = message
+        self.email = email
+        super().__init__(self.message)

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -114,7 +114,6 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = None
 OIDC_RP_CLIENT_ID = "lasuite"
 OIDC_RP_CLIENT_SECRET = "lasuite"
 USER_OIDC_FIELDS_TO_FULLNAME = ["first_name", "last_name"]
-OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = True
 
 #  - OIDC resource server module
 OIDC_RS_AUDIENCE_CLAIM = "client_id"


### PR DESCRIPTION
## Purpose

Introduces the `OIDC_ALLOW_DUPLICATE_EMAILS` setting to disable duplicated email address among users.


## Proposal

- [x] add `OIDC_ALLOW_DUPLICATE_EMAILS` setting with default value to `False`
