### PR TITLE
💥(oidc) normalize setting names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- 💥(oidc) normalize setting names #10
+
 ## [0.0.5] - 2025-04-10
 
 ### Fixed

--- a/documentation/how-to-use-oidc-backend.md
+++ b/documentation/how-to-use-oidc-backend.md
@@ -32,15 +32,14 @@ OIDC_RP_CLIENT_SECRET = "your-client-secret"
 OIDC_OP_TOKEN_ENDPOINT = "https://your-provider.com/token"
 OIDC_OP_USER_ENDPOINT = "https://your-provider.com/userinfo"
 OIDC_OP_LOGOUT_ENDPOINT = "https://your-provider.com/logout"
-OIDC_OP_USER_ENDPOINT_FORMAT = "AUTO"  # AUTO, JSON, or JWT
+OIDC_OP_USER_ENDPOINT_FORMAT = "AUTO"  # AUTO, JSON, or JWT, defaults to AUTO
 
 # Optional settings
 OIDC_USER_SUB_FIELD = "sub"  # Field to store the OIDC subject identifier, defaults to "sub"
-USER_OIDC_FIELDS_TO_FULLNAME = ["first_name", "last_name"]  # Fields used to compute user's full name
-USER_OIDC_ESSENTIAL_CLAIMS = ["sub", "last_name"]  # Claims required for user identification
+OIDC_USERINFO_FULLNAME_FIELDS = ["first_name", "last_name"]  # Fields used to compute user's full name, defaults to `[]`
+OIDC_USERINFO_ESSENTIAL_CLAIMS = ["sub", "last_name"]  # Claims required for user identification, defaults to `[]`
 OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = True  # Allow fallback to email for user identification
-OIDC_CREATE_USER = True  # Automatically create users if they don't exist
-ALLOW_LOGOUT_GET_METHOD = True  # Allow GET method for logout
+OIDC_CREATE_USER = True  # Automatically create users if they don't exist, defaults to `True`
 ```
 
 ### URLs
@@ -63,7 +62,7 @@ Your User model should include the following fields:
 1. `sub` - To store the OIDC subject identifier, you may replace this with 
     another field if needed but needs to set the `OIDC_USER_SUB_FIELD` setting
 2. `email` - For user identification (especially if fallback to email is enabled)
-3. `name` - To store user's full name (computed from fields defined in `USER_OIDC_FIELDS_TO_FULLNAME`)
+3. `name` - To store user's full name (computed from fields defined in `OIDC_USERINFO_FULLNAME_FIELDS`)
 
 ## Authentication Flow
 

--- a/src/lasuite/oidc_login/backends.py
+++ b/src/lasuite/oidc_login/backends.py
@@ -92,7 +92,14 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
                 OIDCUserEndpointFormat.AUTO.name,
             )
         ]
-        self.USER_OIDC_ESSENTIAL_CLAIMS = self.get_settings("USER_OIDC_ESSENTIAL_CLAIMS", [])
+        self.OIDC_USERINFO_FULLNAME_FIELDS = self.get_settings(
+            "OIDC_USERINFO_FULLNAME_FIELDS",
+            [],
+        )
+        self.OIDC_USERINFO_ESSENTIAL_CLAIMS = self.get_settings(
+            "OIDC_USERINFO_ESSENTIAL_CLAIMS",
+            [],
+        )
 
     def get_token(self, payload):
         """
@@ -198,7 +205,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         Verify the presence of essential claims and the "sub" (which is mandatory as defined
         by the OIDC specification) to decide if authentication should be allowed.
         """
-        essential_claims = set(self.USER_OIDC_ESSENTIAL_CLAIMS) | {"sub"}
+        essential_claims = set(self.OIDC_USERINFO_ESSENTIAL_CLAIMS) | {"sub"}
         missing_claims = [claim for claim in essential_claims if claim not in claims]
 
         if missing_claims:
@@ -273,7 +280,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
 
     def compute_full_name(self, user_info):
         """Compute user's full name based on OIDC fields in settings."""
-        name_fields = settings.USER_OIDC_FIELDS_TO_FULLNAME
+        name_fields = self.OIDC_USERINFO_FULLNAME_FIELDS
         full_name = " ".join(user_info[field] for field in name_fields if user_info.get(field))
         return full_name or None
 

--- a/tests/oidc_login/test_backends.py
+++ b/tests/oidc_login/test_backends.py
@@ -509,7 +509,7 @@ def test_authentication_verify_claims_essential_missing(  # noqa: PLR0913
 ):
     """Ensure SuspiciousOperation is raised if essential claims are missing."""
     settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.USER_OIDC_ESSENTIAL_CLAIMS = essential_claims
+    settings.OIDC_USERINFO_ESSENTIAL_CLAIMS = essential_claims
 
     klass = OIDCAuthenticationBackend()
 
@@ -561,7 +561,7 @@ def test_models_oidc_user_getter_empty_sub(django_assert_num_queries, monkeypatc
 def test_authentication_verify_claims_success(django_assert_num_queries, monkeypatch, settings):
     """Ensure user is authenticated when all essential claims are present."""
     settings.OIDC_OP_USER_ENDPOINT = "http://oidc.endpoint.test/userinfo"
-    settings.USER_OIDC_ESSENTIAL_CLAIMS = ["email", "last_name"]
+    settings.OIDC_USERINFO_ESSENTIAL_CLAIMS = ["email", "last_name"]
 
     klass = OIDCAuthenticationBackend()
 

--- a/tests/oidc_resource_server/test_backend.py
+++ b/tests/oidc_resource_server/test_backend.py
@@ -9,7 +9,6 @@ from unittest.mock import Mock, patch
 import pytest
 from django.contrib import auth
 from django.core.exceptions import SuspiciousOperation
-from django.test.utils import override_settings
 from joserfc.errors import InvalidClaimError, InvalidTokenError
 from joserfc.jwt import JWTClaimsRegistry, Token
 from requests.exceptions import HTTPError
@@ -56,15 +55,16 @@ def fixture_jwt_resource_server_backend(settings, mock_authorization_server):
     return JWTResourceServerBackend(mock_authorization_server)
 
 
-@override_settings(OIDC_RS_CLIENT_ID="client_id")
-@override_settings(OIDC_RS_CLIENT_SECRET="client_secret")
-@override_settings(OIDC_RS_ENCRYPTION_ENCODING="A256GCM")
-@override_settings(OIDC_RS_ENCRYPTION_ALGO="RSA-OAEP")
-@override_settings(OIDC_RS_SIGNING_ALGO="RS256")
-@override_settings(OIDC_RS_SCOPES=["scopes"])
 @patch.object(auth, "get_user_model", return_value="foo")
-def test_backend_initialization(mock_get_user_model, mock_authorization_server):
+def test_backend_initialization(mock_get_user_model, mock_authorization_server, settings):
     """Test the ResourceServerBackend initialization."""
+    settings.OIDC_RS_CLIENT_ID = "client_id"
+    settings.OIDC_RS_CLIENT_SECRET = "client_secret"
+    settings.OIDC_RS_ENCRYPTION_ENCODING = "A256GCM"
+    settings.OIDC_RS_ENCRYPTION_ALGO = "RSA-OAEP"
+    settings.OIDC_RS_SIGNING_ALGO = "RS256"
+    settings.OIDC_RS_SCOPES = ["scopes"]
+
     backend = ResourceServerBackend(mock_authorization_server)
 
     mock_get_user_model.assert_called_once()

--- a/tests/oidc_resource_server/test_utils.py
+++ b/tests/oidc_resource_server/test_utils.py
@@ -2,7 +2,6 @@
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
-from django.test.utils import override_settings
 from joserfc.jwk import ECKey, RSAKey
 
 from lasuite.oidc_resource_server.utils import import_private_key_from_settings
@@ -38,10 +37,10 @@ MbyqKyC6DAzv4jEEhHaN7oY=
 """
 
 
-@override_settings(OIDC_RS_PRIVATE_KEY_STR=PRIVATE_KEY_STR_MOCKED)
 @pytest.mark.parametrize("mocked_private_key", [None, ""])
 def test_import_private_key_from_settings_missing_or_empty_key(settings, mocked_private_key):
     """Should raise an exception if the settings 'OIDC_RS_PRIVATE_KEY_STR' is missing or empty."""
+    settings.OIDC_RS_PRIVATE_KEY_STR = PRIVATE_KEY_STR_MOCKED
     settings.OIDC_RS_PRIVATE_KEY_STR = mocked_private_key
 
     with pytest.raises(
@@ -52,30 +51,31 @@ def test_import_private_key_from_settings_missing_or_empty_key(settings, mocked_
 
 
 @pytest.mark.parametrize("mocked_private_key", ["123", "foo", "invalid_key"])
-@override_settings(OIDC_RS_PRIVATE_KEY_STR=PRIVATE_KEY_STR_MOCKED)
-@override_settings(OIDC_RS_ENCRYPTION_KEY_TYPE="RSA")
-@override_settings(OIDC_RS_ENCRYPTION_ALGO="RS256")
 def test_import_private_key_from_settings_incorrect_key(settings, mocked_private_key):
     """Should raise an exception if the setting 'OIDC_RS_PRIVATE_KEY_STR' has an incorrect value."""
+    settings.OIDC_RS_PRIVATE_KEY_STR = PRIVATE_KEY_STR_MOCKED
+    settings.OIDC_RS_ENCRYPTION_KEY_TYPE = "RSA"
+    settings.OIDC_RS_ENCRYPTION_ALGO = "RS256"
     settings.OIDC_RS_PRIVATE_KEY_STR = mocked_private_key
 
     with pytest.raises(ImproperlyConfigured, match="OIDC_RS_PRIVATE_KEY_STR setting is wrong."):
         import_private_key_from_settings()
 
 
-@override_settings(OIDC_RS_PRIVATE_KEY_STR=PRIVATE_KEY_STR_MOCKED)
-@override_settings(OIDC_RS_ENCRYPTION_KEY_TYPE="RSA")
-@override_settings(OIDC_RS_ENCRYPTION_ALGO="RS256")
-def test_import_private_key_from_settings_success_rsa_key():
+def test_import_private_key_from_settings_success_rsa_key(settings):
     """Should import private key string as an RSA key."""
+    settings.OIDC_RS_PRIVATE_KEY_STR = PRIVATE_KEY_STR_MOCKED
+    settings.OIDC_RS_ENCRYPTION_KEY_TYPE = "RSA"
+    settings.OIDC_RS_ENCRYPTION_ALGO = "RS256"
     private_key = import_private_key_from_settings()
     assert isinstance(private_key, RSAKey)
 
 
-@override_settings(OIDC_RS_PRIVATE_KEY_STR=PRIVATE_KEY_STR_MOCKED)
-@override_settings(OIDC_RS_ENCRYPTION_KEY_TYPE="EC")
-@override_settings(OIDC_RS_ENCRYPTION_ALGO="ES256")
-def test_import_private_key_from_settings_success_ec_key():
+def test_import_private_key_from_settings_success_ec_key(settings):
     """Should import private key string as an EC key."""
+    settings.OIDC_RS_PRIVATE_KEY_STR = PRIVATE_KEY_STR_MOCKED
+    settings.OIDC_RS_ENCRYPTION_KEY_TYPE = "EC"
+    settings.OIDC_RS_ENCRYPTION_ALGO = "ES256"
+
     private_key = import_private_key_from_settings()
     assert isinstance(private_key, ECKey)

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -108,8 +108,6 @@ AUTHENTICATION_BACKENDS = [
 OIDC_AUTHENTICATE_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationRequestView"
 OIDC_CALLBACK_CLASS = "lasuite.oidc_login.views.OIDCAuthenticationCallbackView"
 
-ALLOW_LOGOUT_GET_METHOD = True
-
 OIDC_OP_TOKEN_ENDPOINT = None
 OIDC_OP_USER_ENDPOINT = None
 OIDC_OP_LOGOUT_ENDPOINT = None

--- a/tests/test_project/settings.py
+++ b/tests/test_project/settings.py
@@ -116,7 +116,7 @@ OIDC_OP_LOGOUT_ENDPOINT = None
 OIDC_OP_AUTHORIZATION_ENDPOINT = None
 OIDC_RP_CLIENT_ID = "lasuite"
 OIDC_RP_CLIENT_SECRET = "lasuite"
-USER_OIDC_FIELDS_TO_FULLNAME = ["first_name", "last_name"]
+OIDC_USERINFO_FULLNAME_FIELDS = ["first_name", "last_name"]
 OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = True
 
 #  - OIDC resource server module


### PR DESCRIPTION
## Purpose

The first implementation was trying to keep names used across our projects but we better make things clean before broad adoption of the library.


## Proposal

- [x] `USER_OIDC_FIELDS_TO_FULLNAME` becomes `OIDC_USERINFO_FULLNAME_FIELDS`
- [x] `USER_OIDC_ESSENTIAL_CLAIMS` becomes `OIDC_USERINFO_ESSENTIAL_CLAIMS`