### PR TITLE
🐛(oidc) fix user info endpoint format auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(oidc) fix user info endpoint format auto #12
+
 ## [0.0.6] - 2025-04-11
 
 ### Changed

--- a/src/lasuite/oidc_login/backends.py
+++ b/src/lasuite/oidc_login/backends.py
@@ -1,6 +1,7 @@
 """Authentication Backends for OIDC."""
 
 import logging
+from cgi import parse_header
 from functools import lru_cache
 from json import JSONDecodeError
 
@@ -182,7 +183,8 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         if self.OIDC_OP_USER_ENDPOINT_FORMAT == OIDCUserEndpointFormat.AUTO:
             # In auto mode, we check the content type of the response to determine
             # the expected format.
-            if user_response.headers.get("Content-Type") == "application/jwt":
+            content_type, _params = parse_header(user_response.headers.get("Content-Type", ""))
+            if content_type.lower() == "application/jwt":
                 _expected_format = OIDCUserEndpointFormat.JWT
             else:
                 _expected_format = OIDCUserEndpointFormat.JSON


### PR DESCRIPTION
## Purpose

The content type may contain more information than just the content type, like the charset.


## Proposal

We use the python CGI header parser to ignore other parameter to detect the content type.

- [x] update the OIDC login backend
- [x] add a test to check it manages properly content type like `application/jwt; charset=utf-8`