### PR TITLE
🐛(oidc) use the `OIDC_USER_SUB_FIELD` when needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🐛(oidc) fix resource server client when using JSON introspection #16
 - 🔊(oidc) improve resource server log for inactive user #17
+- 🐛(oidc) use the OIDC_USER_SUB_FIELD when needed #18
 
 ## [0.0.7] - 2025-04-23
 

--- a/tests/oidc_login/test_backends.py
+++ b/tests/oidc_login/test_backends.py
@@ -646,3 +646,21 @@ def test_post_get_or_create_user_called_for_new_user(monkeypatch, django_assert_
         {"sub": "new-sub", "email": "new@example.com", "name": "New User"},
         True,
     )
+
+
+def test_user_sub_field_for_create(settings):
+    """Test that the OIDC_USER_SUB_FIELD setting is used to create the user."""
+    settings.OIDC_USER_SUB_FIELD = "email"
+
+    OIDCAuthenticationBackend().create_user({"email": "test@example.com"})
+
+    assert User.objects.get(email="test@example.com")
+
+
+def test_user_sub_field_for_get_existing_user(settings):
+    """Test that the OIDC_USER_SUB_FIELD setting is used to get the existing user."""
+    settings.OIDC_USER_SUB_FIELD = "email"
+    settings.OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = False
+
+    User.objects.create(email="test@example.com")
+    assert OIDCAuthenticationBackend().get_existing_user("test@example.com", None)


### PR DESCRIPTION
## Purpose

The code allows to not use `sub` to store the sub data of the user, but some part of the code, where still using the hardcoded `sub` attribute.


## Proposal

Use the `OIDC_USER_SUB_FIELD` instead of the "sub" string.
