### PR TITLE
🩹(oidc) remove deprecated `cgi` use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - 🐛(oidc) fix resource server client when using JSON introspection #16
 - 🔊(oidc) improve resource server log for inactive user #17
 - 🐛(oidc) use the OIDC_USER_SUB_FIELD when needed #18
+- 🩹(oidc) remove deprecated cgi use #19
 
 ## [0.0.7] - 2025-04-23
 

--- a/src/lasuite/oidc_login/backends.py
+++ b/src/lasuite/oidc_login/backends.py
@@ -1,7 +1,6 @@
 """Authentication Backends for OIDC."""
 
 import logging
-from cgi import parse_header
 from functools import lru_cache
 from json import JSONDecodeError
 
@@ -9,6 +8,7 @@ import requests
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
+from django.utils.http import parse_header_parameters
 from django.utils.translation import gettext_lazy as _
 from mozilla_django_oidc.auth import (
     OIDCAuthenticationBackend as MozillaOIDCAuthenticationBackend,
@@ -181,7 +181,7 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
         if self.OIDC_OP_USER_ENDPOINT_FORMAT == OIDCUserEndpointFormat.AUTO:
             # In auto mode, we check the content type of the response to determine
             # the expected format.
-            content_type, _params = parse_header(user_response.headers.get("Content-Type", ""))
+            content_type, _params = parse_header_parameters(user_response.headers.get("Content-Type", ""))
             if content_type.lower() == "application/jwt":
                 _expected_format = OIDCUserEndpointFormat.JWT
             else:


### PR DESCRIPTION
## Purpose

The `cgi` module is deprecated.

## Proposal

Use Django to parse the content type header.
