### PR TITLE
♻️(malware_detection) retry getting analyse result sooner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ♻️(malware_detection) retry getting analyse result sooner
+
 ## [0.0.8] - 2025-05-06
 
 ### Added
 
-✨(malware_detection) add a module malware_detection #11
+- ✨(malware_detection) add a module malware_detection #11
 
 ### Fixed
 

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -145,7 +145,7 @@ class JCOPBackend(BaseBackend):
         if response.status_code == HTTPStatus.OK:
             content = response.json()
             analyse_file_async.apply_async(
-                countdown=30,
+                countdown=5,
                 args=(file_path,),
                 kwargs={"file_hash": content["id"], **kwargs},
             )

--- a/src/lasuite/malware_detection/tasks/jcop.py
+++ b/src/lasuite/malware_detection/tasks/jcop.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 @shared_task(
     bind=True,
-    default_retry_delay=30,
-    max_retries=10,
+    default_retry_delay=3,
+    max_retries=100,
     dont_autoretry_for=(MalwareDetectionInvalidAuthenticationError,),
 )
 def analyse_file_async(

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -309,46 +309,6 @@ def test_jcop_backend_analyse_file_async_request_error(
     jcop_callback.assert_not_called()
 
 
-# @responses.activate
-# @pytest.mark.parametrize("used_kwargs", [{}, {"foo": "bar"}])
-# @pytest.mark.parametrize("with_file_hash", [True, False])
-# def test_jcop_backend_analyse_file_async_request_error_max_retry(
-#     jcop_generate_file_path, jcop_backend_parameters, used_kwargs, with_file_hash
-# ):
-#     """Test with a request exception should raise a Retry exception."""
-#     file_path, file_hash = jcop_generate_file_path
-
-#     # Mock the results endpoint
-#     responses.add(
-#         responses.GET,
-#         f"https://malware_detection.tld/api/v1/results/{file_hash}",
-#         body=requests.exceptions.RequestException(),
-#         headers={
-#             "X-Auth-Token": "xxxx",
-#             "Accept": "application/json",
-#         },
-#         status=200,
-#     )
-#     with mock.patch.object(analyse_file_async, "retry"):
-#         analyse_file_async.max_retries = 0
-#         analyse_file_async(
-#             file_path,
-#             file_hash=file_hash if with_file_hash else None,
-#             **jcop_backend_parameters,
-#             **used_kwargs,
-#         )
-
-#     jcop_callback.assert_called_once_with(
-#         file_path,
-#         ReportStatus.UNKNOWN,
-#         error_info={
-#             "error": "Max retries fetching results exceeded",
-#             "error_code": 5000,
-#         },
-#         **used_kwargs,
-#     )
-
-
 @responses.activate
 @pytest.mark.parametrize("used_kwargs", [{}, {"foo": "bar"}])
 @pytest.mark.parametrize("with_file_hash", [True, False])
@@ -401,7 +361,7 @@ def test_jcop_backend_trigger_new_analysis_success(jcop_generate_file_path, jcop
     with mock.patch.object(analyse_file_async, "apply_async") as mock_apply_async:
         jcop_backend.trigger_new_analysis(file_path, **used_kwargs)
         mock_apply_async.assert_called_once_with(
-            countdown=30,
+            countdown=5,
             args=(file_path,),
             kwargs={
                 "file_hash": file_hash,


### PR DESCRIPTION
## Purpose

Once an analyse started, we were wiating 30 seconds to try having a first time the result and then the retry delay was always equal to 30 seconds between every retries. JCOP ask us to reduce this waiting time to few seconds, an analyse job should start quickly and depending the file size the result will be available in few seconds.

## Proposal

- [x] ♻️(malware_detection) retry getting analyse result sooner
