### PR TITLE
📝(doc) add missing OIDC_OP_INTROSPECTION_ENDPOINT usage

### DIFF
--- a/documentation/how-to-use-oidc-resource-server-backend.md
+++ b/documentation/how-to-use-oidc-resource-server-backend.md
@@ -44,6 +44,7 @@ OIDC_RP_CLIENT_SECRET = "your-client-secret"
 # Authorization server endpoints
 OIDC_OP_TOKEN_ENDPOINT = "https://your-provider.com/token"
 OIDC_OP_USER_ENDPOINT = "https://your-provider.com/userinfo"
+OIDC_OP_INTROSPECTION_ENDPOINT = "https://your-provider.com/token/introspect"
 OIDC_OP_USER_ENDPOINT_FORMAT = "AUTO"  # AUTO, JSON, or JWT
 ```
 


### PR DESCRIPTION
## Purpose

In the how to use oidc resource server backend documentation, tu usage of the OIDC_OP_INTROSPECTION_ENDPOINT settings was missing.

## Proposal

- [x] 📝(doc) add missing OIDC_OP_INTROSPECTION_ENDPOINT usage