### PR TITLE
🐛(oidc) fix `update_user` when `User.sub` is nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(oidc) fix `update_user` when `User.sub` is nullable #31
+
+
 ## [0.0.15] - 2025-10-24
 
 ### Added

--- a/src/lasuite/oidc_login/backends.py
+++ b/src/lasuite/oidc_login/backends.py
@@ -306,7 +306,8 @@ class OIDCAuthenticationBackend(MozillaOIDCAuthenticationBackend):
 
             claim_value = claims.get(key)
             if claim_value and claim_value != getattr(user, key):
+                setattr(user, key, claim_value)
                 updated_claims[key] = claim_value
 
         if updated_claims:
-            self.UserModel.objects.filter(sub=user.sub).update(**updated_claims)
+            user.save(update_fields=tuple(updated_claims.keys()))

--- a/tests/test_project/user/models.py
+++ b/tests/test_project/user/models.py
@@ -7,7 +7,7 @@ from django.db import models
 class User(AbstractBaseUser):
     """User model for the application."""
 
-    sub = models.CharField("sub", max_length=255, unique=True)
+    sub = models.CharField("sub", max_length=255, unique=True, null=True)  # noqa: DJ001
     name = models.CharField("name", max_length=255, blank=True, null=True)  # noqa: DJ001
     email = models.EmailField("email address", blank=True, null=True)  # noqa: DJ001
     is_active = models.BooleanField("active", default=True)


### PR DESCRIPTION
En utilisant le module OIDC sur un autre projet, je me suis rendu compte que le update_user_if_needed ne gère pas correctement le cas d'un projet avec User.sub nullable (ex: un projet qui a commencé avec un autre moyen d'authentification et qui migre sur OIDC, ou un projet qui a plusieurs moyens d'authentification actif).

## Reproduction du bug

1. Avoir un modèle User avec un champs sub nullable
2. Laisser plusieurs utilisateurs se connecter avec un autre mode d'authentification
3. Activer l'OIDC avec le backend de django-lasuite (pour se faire on va ajouter la colonne sub nullable avec valeur initiale null)
4. Lorsque les utilisateurs se connect avec OIDC sur un compte déjà existant (meme email), échec de la requête sql car elle essaie de mettre à jour le sub de tous les users avec `sub is NULL`, comme il y a une unicité sur la colonne, la requête échoue

## Proposal

Modifier la requête de mise à jour pour cibler uniquement l'utilisateur trouvé.

## Note

La requête actuelle échoue également si on utilise un champs sub custom via settings.OIDC_USER_SUB_FIELD