### PR TITLE
👔(oidc) consider urls as refreshable no matter the HTTP method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - 🐛(joserfc) refactor JWT handling with joserfc library updates #35
+- 👔(oidc) consider urls as refreshable no matter the HTTP method
 
 ## [0.0.17] - 2025-10-27
 

--- a/tests/oidc_login/test_middleware.py
+++ b/tests/oidc_login/test_middleware.py
@@ -113,11 +113,12 @@ def test_basic_auth_disabled(oidc_settings):  # pylint: disable=unused-argument
 
 
 @responses.activate
-def test_successful_token_refresh(oidc_settings):  # pylint: disable=unused-argument
-    """Test that the middleware successfully refreshes the token."""
+@pytest.mark.parametrize("http_method", ["get", "post", "put", "patch", "delete", "head", "options"])
+def test_successful_token_refresh(oidc_settings, http_method):  # pylint: disable=unused-argument
+    """Test that the middleware successfully refreshes the token for any HTTP method."""
     user = factories.UserFactory()
 
-    request = RequestFactory().get("/test")
+    request = getattr(RequestFactory(), http_method)("/test")
     request.user = user
 
     get_response = MagicMock()
@@ -166,10 +167,14 @@ def test_non_expired_token(oidc_settings):  # pylint: disable=unused-argument
 
 
 @responses.activate
-def test_refresh_token_request_timeout(oidc_settings):  # pylint: disable=unused-argument
-    """Test that the middleware returns a 401 response when the token refresh request times out."""
+@pytest.mark.parametrize("http_method", ["get", "post", "put", "patch", "delete", "head", "options"])
+def test_refresh_token_request_timeout(oidc_settings, http_method):  # pylint: disable=unused-argument
+    """
+    Test that the middleware returns a 401 response when the token
+    refresh request times out for any HTTP method.
+    """
     user = factories.UserFactory()
-    request = RequestFactory().get("/test")
+    request = getattr(RequestFactory(), http_method)("/test")
     request.user = user
 
     get_response = MagicMock()


### PR DESCRIPTION
## Purpose

Currently, only `GET` method as considered as refreshable url as it could be weird to return a redirect response for other kind of HTTP methods. On our side, we assume to be always in a XHR context so we don't want to be bothered by redirects and in case the session has expired we returned a 401 status. So we can safely ignore the request HTTP method to check if the url is refreshable.