### PR TITLE
🐛(oidc) make `iss` claim optional in introspection response validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(oidc) make `iss` claim optional in introspection response validation
+
 ## [0.0.25] - 2026-03-10
 
 ### Added

--- a/src/lasuite/oidc_resource_server/backend.py
+++ b/src/lasuite/oidc_resource_server/backend.py
@@ -59,7 +59,7 @@ class ResourceServerBackend:
             )
 
         self._introspection_claims_registry = jose_jwt.JWTClaimsRegistry(
-            iss={"essential": True, "value": self._authorization_server_client.url},
+            iss={"essential": False, "value": self._authorization_server_client.url},
             active={"essential": True},
             # scope is optional in RFC, but mandatory here, it may be missing if `active` is False
             scope={"essential": False},  # content validated in _verify_user_info

--- a/tests/oidc_resource_server/test_backend.py
+++ b/tests/oidc_resource_server/test_backend.py
@@ -97,7 +97,7 @@ def test_backend_initialization(mock_get_user_model, settings):
     assert backend._introspection_claims_registry.options == {
         "active": {"essential": True},
         "client_id": {"essential": False},
-        "iss": {"essential": True, "value": "https://auth.server.com"},
+        "iss": {"essential": False, "value": "https://auth.server.com"},
         "scope": {"essential": False},
     }
 


### PR DESCRIPTION
## Purpose

RFC 7662 does not require the `iss` field in token introspection responses. Some providers (e.g. GitLab via Doorkeeper) do not include it, causing authentication to fail. The value is still validated when present.

Fixes #67 

## Proposal

Make `iss` field optional but still validates it when present.