### PR TITLE
✨(oidc) allow login_hint param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ✨(oidc) allow login_hint param #69
+
 ## [0.0.25] - 2026-03-10
 
 ### Added

--- a/src/lasuite/oidc_login/views.py
+++ b/src/lasuite/oidc_login/views.py
@@ -758,9 +758,14 @@ class OIDCAuthenticationRequestView(MozillaOIDCAuthenticationRequestView):
         if extra_params is None:
             extra_params = {}
 
-        if request.GET.get("silent", "").lower() == "true":
+        silent = request.GET.get("silent", "").lower() == "true"
+        login_hint = request.GET.get("login_hint", "")
+        if silent or login_hint:
             extra_params = copy.deepcopy(extra_params)
-            extra_params.update({"prompt": "none"})
-            request.session["silent"] = True
+            if silent:
+                extra_params.update({"prompt": "none"})
+                request.session["silent"] = True
+            if login_hint:
+                extra_params.update({"login_hint": login_hint})
 
         return extra_params

--- a/tests/oidc_login/test_views.py
+++ b/tests/oidc_login/test_views.py
@@ -332,6 +332,61 @@ def test_view_authentication_silent_true(settings, mocked_extra_params_setting):
     assert request.session.get("silent") is True
 
 
+@pytest.mark.parametrize("mocked_extra_params_setting", [{"foo": 123}, {}, None])
+def test_view_authentication_login_hint(settings, mocked_extra_params_setting):
+    """If 'login_hint' parameter is set, this login_hint should be forwarded to the IDP."""
+    settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = mocked_extra_params_setting
+
+    user = factories.UserFactory()
+
+    request = RequestFactory().request()
+    request.user = user
+    request.GET = {"login_hint": "foo@bar.com"}
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    view = OIDCAuthenticationRequestView()
+    extra_params = view.get_extra_params(request)
+    expected_params = {"login_hint": "foo@bar.com"}
+
+    assert (
+        extra_params == {**mocked_extra_params_setting, **expected_params}
+        if mocked_extra_params_setting
+        else expected_params
+    )
+
+
+@pytest.mark.parametrize("mocked_extra_params_setting", [{"foo": 123}, {}, None])
+def test_view_authentication_login_hint_and_silent_true(settings, mocked_extra_params_setting):
+    """
+    If 'login_hint' parameter is set, and 'silent' parameter is set to True:
+    - the 'login_hint' should be forwarded to the IDP,
+    - the silent login should be triggered.
+    """
+    settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = mocked_extra_params_setting
+
+    user = factories.UserFactory()
+
+    request = RequestFactory().request()
+    request.user = user
+    request.GET = {"login_hint": "foo@bar.com", "silent": "true"}
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    view = OIDCAuthenticationRequestView()
+    extra_params = view.get_extra_params(request)
+    expected_params = {"login_hint": "foo@bar.com", "prompt": "none"}
+
+    assert (
+        extra_params == {**mocked_extra_params_setting, **expected_params}
+        if mocked_extra_params_setting
+        else expected_params
+    )
+    assert request.session.get("silent") is True
+
+
 @mock.patch.object(
     OIDCAuthenticationCallbackView,
     "failure_url",


### PR DESCRIPTION


## Purpose

Make it possible for a member institution of the Renater federation to share a link (for example, https://visio.numerique.gouv.fr/api/v1.0/authenticate?silent=false&returnTo=https%3A%2F%2Fvisio.numerique.gouv.fr%2F&login_hint=bouton@renater.fr ) so that users are taken directly to the Renater Discovery portal (thus avoiding having to click "Continuer avec Fédération Renater" on ProConnect)


## Proposal

Currently, we accept a “silent” parameter; if it is `true`, we pass `prompt=none` to ProConnect.
This PR adds support for a `login_hint` parameter (see https://partenaires.proconnect.gouv.fr/docs/fournisseur-service/login_hint_usage )

So, if we send https://visio.numerique.gouv.fr/api/v1.0/authenticate?silent=false&returnTo=https%3A%2F%2Fvisio.numerique.gouv.fr%2F&login_hint=bouton@renater.fr to a user, they will be redirected to https://auth.agentconnect.gouv.fr/api/v2/authorize?response_type=code&scope=openid+email+given_name+usual_name&client_id=b96f8900-fbc0-40f6-85e6-af3f519ccb9f&redirect_uri=https%3A%2F%2Fvisio.numerique.gouv.fr%2Fapi%2Fv1.0%2Fcallback%2F&state=xxx&acr_values=eidas1&nonce=yyy&login_hint=bouton@renater.fr (instead of https://auth.agentconnect.gouv.fr/api/v2/authorize?response_type=code&scope=openid+email+given_name+usual_name&client_id=b96f8900-fbc0-40f6-85e6-af3f519ccb9f&redirect_uri=https%3A%2F%2Fvisio.numerique.gouv.fr%2Fapi%2Fv1.0%2Fcallback%2F&state=xxx&acr_values=eidas1&nonce=yyy currently) and will therefore be redirected directly to https://discovery.renater.fr/agentconnect/zzz

fix: https://github.com/suitenumerique/meet/issues/1227