### PR TITLE
🔖(patch) bump release to 0.0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.0.26] - 2026-04-03
+
 ### Changed
 
 - ✨(oidc) allow login_hint param #69
@@ -212,7 +214,8 @@ and this project adheres to
 - ✨(oidc) add the authentication backends #2
 - ✨(oidc) add refresh token tools #3
 
-[unreleased]: https://github.com/suitenumerique/django-lasuite/compare/v0.0.25...main
+[unreleased]: https://github.com/suitenumerique/django-lasuite/compare/v0.0.26...main
+[0.0.26]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.26
 [0.0.25]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.25
 [0.0.24]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.24
 [0.0.23]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-lasuite"
-version = "0.0.25"
+version = "0.0.26"
 description = "Django La Suite - A Django library"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Changed

- ✨(oidc) allow login_hint param #69

Fixed

- 🐛(oidc) make `iss` claim optional in introspection response validation

