### PR TITLE
✨(oidc) allow to configure forwarded params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- ✨(oidc) allow to configure forwarded params
+
 ## [0.0.26] - 2026-04-03
 
 ### Changed

--- a/documentation/how-to-use-oidc-backend.md
+++ b/documentation/how-to-use-oidc-backend.md
@@ -40,6 +40,7 @@ OIDC_USERINFO_FULLNAME_FIELDS = ["first_name", "last_name"]  # Fields used to co
 OIDC_USERINFO_ESSENTIAL_CLAIMS = ["sub", "last_name"]  # Claims required for user identification, defaults to `[]`
 OIDC_FALLBACK_TO_EMAIL_FOR_IDENTIFICATION = True  # Allow fallback to email for user identification
 OIDC_CREATE_USER = True  # Automatically create users if they don't exist, defaults to `True`
+OIDC_AUTH_REQUEST_FORWARDED_PARAMS = ["login_hint"] # Forwardable query parameters defaults to `['login_hint'] `
 ```
 
 ### URLs

--- a/src/lasuite/oidc_login/views.py
+++ b/src/lasuite/oidc_login/views.py
@@ -749,23 +749,27 @@ class OIDCAuthenticationRequestView(MozillaOIDCAuthenticationRequestView):
 
     def get_extra_params(self, request):
         """
-        Handle 'prompt' extra parameter for the silent login flow.
+        Build the extra parameters forwarded to the IdP authentication request.
 
-        Silent login (?silent=true) adds prompt=none to check for active
-        SSO session without displaying UI.
+        - Silent login (?silent=true) adds prompt=none to check for an active
+          SSO session without displaying any UI.
+        - Any query parameter listed in the OIDC_AUTH_REQUEST_FORWARDED_PARAMS
+          setting (defaults to ["login_hint"]) is forwarded as-is to the IdP
+          when present in the incoming request.
         """
         extra_params = self.get_settings("OIDC_AUTH_REQUEST_EXTRA_PARAMS", None)
         if extra_params is None:
             extra_params = {}
 
         silent = request.GET.get("silent", "").lower() == "true"
-        login_hint = request.GET.get("login_hint", "")
-        if silent or login_hint:
+        forwarded_params = self.get_settings("OIDC_AUTH_REQUEST_FORWARDED_PARAMS", ["login_hint"])
+        forwarded = {param: request.GET[param] for param in forwarded_params if request.GET.get(param)}
+
+        if silent or forwarded:
             extra_params = copy.deepcopy(extra_params)
+            extra_params.update(forwarded)
             if silent:
                 extra_params.update({"prompt": "none"})
                 request.session["silent"] = True
-            if login_hint:
-                extra_params.update({"login_hint": login_hint})
 
         return extra_params

--- a/tests/oidc_login/test_views.py
+++ b/tests/oidc_login/test_views.py
@@ -333,8 +333,11 @@ def test_view_authentication_silent_true(settings, mocked_extra_params_setting):
 
 
 @pytest.mark.parametrize("mocked_extra_params_setting", [{"foo": 123}, {}, None])
-def test_view_authentication_login_hint(settings, mocked_extra_params_setting):
-    """If 'login_hint' parameter is set, this login_hint should be forwarded to the IDP."""
+def test_view_authentication_default_forwarded_params(settings, mocked_extra_params_setting):
+    """
+    By default, forwarded params settings is set to ['login_hint'],
+    so if this parameter is set, this login_hint should be forwarded to the IDP.
+    """
     settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = mocked_extra_params_setting
 
     user = factories.UserFactory()
@@ -358,10 +361,10 @@ def test_view_authentication_login_hint(settings, mocked_extra_params_setting):
 
 
 @pytest.mark.parametrize("mocked_extra_params_setting", [{"foo": 123}, {}, None])
-def test_view_authentication_login_hint_and_silent_true(settings, mocked_extra_params_setting):
+def test_view_authentication_default_forwarded_params_and_silent_true(settings, mocked_extra_params_setting):
     """
-    If 'login_hint' parameter is set, and 'silent' parameter is set to True:
-    - the 'login_hint' should be forwarded to the IDP,
+    If forwaded parameters are set, and 'silent' parameter is set to True:
+    - params should be forwarded to the IDP,
     - the silent login should be triggered.
     """
     settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = mocked_extra_params_setting
@@ -385,6 +388,43 @@ def test_view_authentication_login_hint_and_silent_true(settings, mocked_extra_p
         else expected_params
     )
     assert request.session.get("silent") is True
+
+
+def test_view_authentication_forwarded_params_custom(settings):
+    """Query parameters listed in OIDC_AUTH_REQUEST_FORWARDED_PARAMS should be forwarded to the IdP."""
+    settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = None
+    settings.OIDC_AUTH_REQUEST_FORWARDED_PARAMS = ["login_hint", "idp_hint"]
+
+    request = RequestFactory().request()
+    request.user = factories.UserFactory()
+    # 'unlisted' is dropped because it is not part of the forwarded params
+    request.GET = {"login_hint": "foo@bar.com", "idp_hint": "some-idp", "unlisted": "nope"}
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    view = OIDCAuthenticationRequestView()
+    extra_params = view.get_extra_params(request)
+
+    assert extra_params == {"login_hint": "foo@bar.com", "idp_hint": "some-idp"}
+
+
+def test_view_authentication_forwarded_params_empty(settings):
+    """An empty OIDC_AUTH_REQUEST_FORWARDED_PARAMS setting should disable any forwarding."""
+    settings.OIDC_AUTH_REQUEST_EXTRA_PARAMS = None
+    settings.OIDC_AUTH_REQUEST_FORWARDED_PARAMS = []
+
+    request = RequestFactory().request()
+    request.user = factories.UserFactory()
+    request.GET = {"login_hint": "foo@bar.com"}
+
+    middleware = SessionMiddleware(get_response=lambda x: x)
+    middleware.process_request(request)
+
+    view = OIDCAuthenticationRequestView()
+    extra_params = view.get_extra_params(request)
+
+    assert extra_params == {}
 
 
 @mock.patch.object(


### PR DESCRIPTION
## Purpose

Previously, d5f0c56f4d10610a1345d52c5e2828156192c7d5 allows to forward `login_hint` to identity provider. Today we need to forward other params. Instead to stack conditional statements to forward those parameters, we add a settings
`OIDC_AUTH_REQUEST_FORWARDED_PARAMS` configurable by the consumer For backward compatibility, the default value of this settings is `["login_hint"]` 