### PR TITLE
🐛(malware) fix JCOP processing slots exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Changed
 
 - ✨(malware) fill all free slots in launch_next_analysis
+- ♻️(malware) rename launch_next_analysis to launch_next_analyses
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to
 - 🐛(malware) handle polling retry exhaustion in analyse_file_async
 - 🐛(malware) pass file_hash to failed_analysis in retry guards
 - 🐛(malware) make delete_detection tolerant to duplicate paths
+- 🐛(malware) make failed_analysis tolerant to duplicate paths
 
 ## [0.0.28] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- ✨(malware) fill all free slots in launch_next_analysis
+
 ### Fixed
 
 - 🐛(malware) handle polling retry exhaustion in analyse_file_async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to
 ### Fixed
 
 - 🐛(malware) handle polling retry exhaustion in analyse_file_async
+- 🐛(malware) pass file_hash to failed_analysis in retry guards
 
 ## [0.0.28] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to
 
 - 🐛(malware) handle polling retry exhaustion in analyse_file_async
 - 🐛(malware) pass file_hash to failed_analysis in retry guards
+- 🐛(malware) make delete_detection tolerant to duplicate paths
 
 ## [0.0.28] - 2026-08-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛(malware) handle polling retry exhaustion in analyse_file_async
+
 ## [0.0.28] - 2026-08-21
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to
 - 🐛(malware) pass file_hash to failed_analysis in retry guards
 - 🐛(malware) make delete_detection tolerant to duplicate paths
 - 🐛(malware) make failed_analysis tolerant to duplicate paths
+- 🐛(malware) stop stacking duplicate detections in analyse_file
 
 ## [0.0.28] - 2026-08-21
 

--- a/documentation/how-to-use-malware-detection-backend.md
+++ b/documentation/how-to-use-malware-detection-backend.md
@@ -87,6 +87,7 @@ parameters:
 - `callback_path`: the full path to the callback.
 - `result_timeout`: The timeout for the result request. Default: 30 (optional)
 - `submit_timeout`: The timeout for the submit request. Default: 600 (optional)
+- `max_processing_files`: The maximum number of files analysed at the same time, further `analyse_file` calls are queued in database. Default: 15 (optional)
 
 Example:
 
@@ -100,3 +101,12 @@ settings.MALWARE_DETECTION = {
     },
 }
 ```
+
+#### Required scheduled jobs
+
+The JCOP backend queues analyses in database: at most `max_processing_files` records are in the `processing` status at the same time, the others wait in the `pending` status. If a worker dies before reporting an analysis result (worker restart or OOM-kill, lost broker message, ...), the `processing` record is never released and its slot stays occupied: without a reconciliation job, the queue can end up deadlocked with `pending` records accumulating forever.
+
+To recover automatically from these situations, you must schedule the two management commands below (cron, celery beat calling `call_command`, ...):
+
+- `reschedule_processing_analysis`: re-dispatches the analysis of the records stuck in the `processing` status for more than `settings.MALWARE_DETECTION_RESCHEDULE_PROCESSING_ANALYSIS_DAYS` days (default: 3). A daily run is enough.
+- `check_analysis_pending`: fills the free processing slots with the waiting `pending` records. Schedule it more frequently (e.g. every 5 to 15 minutes) to re-kick the queue.

--- a/src/lasuite/malware_detection/backends/base.py
+++ b/src/lasuite/malware_detection/backends/base.py
@@ -34,8 +34,8 @@ class BaseBackend(ABC):
         """Analyse a file and call the callback with the result."""
 
     @abstractmethod
-    def launch_next_analysis(self) -> None:
-        """Launch the next analysis."""
+    def launch_next_analyses(self) -> None:
+        """Launch the pending analyses."""
 
     @abstractmethod
     def reschedule_processing_task(self, malware_detection_record: MalwareDetection) -> None:

--- a/src/lasuite/malware_detection/backends/dummy.py
+++ b/src/lasuite/malware_detection/backends/dummy.py
@@ -12,8 +12,8 @@ class DummyBackend(BaseBackend):
         """Analyse a file and call the callback with the result."""
         self.callback(file_path, ReportStatus.SAFE, error_info={}, **kwargs)
 
-    def launch_next_analysis(self) -> None:
-        """Launch the next analysis."""
+    def launch_next_analyses(self) -> None:
+        """Launch the pending analyses."""
 
     def reschedule_processing_task(self, malware_detection_record: MalwareDetection) -> None:
         """Reschedule the processing task for a malware detection record."""

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -56,12 +56,16 @@ class JCOPBackend(BaseBackend):
             )
             return
 
-        MalwareDetection.objects.create(
+        if not MalwareDetection.objects.filter(
             path=file_path,
-            status=MalwareDetectionStatus.PENDING,
-            backend=self.backend_name,
-            parameters=kwargs,
-        )
+            status__in=[MalwareDetectionStatus.PENDING, MalwareDetectionStatus.PROCESSING],
+        ).exists():
+            MalwareDetection.objects.create(
+                path=file_path,
+                status=MalwareDetectionStatus.PENDING,
+                backend=self.backend_name,
+                parameters=kwargs,
+            )
 
         self.launch_next_analysis()
 

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -67,7 +67,7 @@ class JCOPBackend(BaseBackend):
                 parameters=kwargs,
             )
 
-        self.launch_next_analysis()
+        self.launch_next_analyses()
 
     def reschedule_processing_task(self, malware_detection_record: MalwareDetection) -> None:
         """Reschedule the processing task for a malware detection record."""
@@ -89,7 +89,7 @@ class JCOPBackend(BaseBackend):
             **malware_detection_record.parameters,
         )
 
-    def launch_next_analysis(self) -> None:
+    def launch_next_analyses(self) -> None:
         """Launch the pending analyses until all processing slots are filled."""
         free_slots = (
             self.max_processing_files
@@ -146,7 +146,7 @@ class JCOPBackend(BaseBackend):
         if not updated:
             logger.warning("Detection %s not found", file_path)
 
-        self.launch_next_analysis()
+        self.launch_next_analyses()
         self.callback(
             file_path,
             status if status is not None else ReportStatus.UNKNOWN,
@@ -161,7 +161,7 @@ class JCOPBackend(BaseBackend):
     def succeed_analysis(self, file_path: str, **kwargs) -> None:
         """Handle a successful analysis."""
         self.delete_detection(file_path)
-        self.launch_next_analysis()
+        self.launch_next_analyses()
         self.callback(file_path, ReportStatus.SAFE, error_info={}, **kwargs)
 
     def check_analysis(self, file_path: str, file_hash: str | None = None, **kwargs) -> bool:

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -117,14 +117,10 @@ class JCOPBackend(BaseBackend):
         ).filter(~Q(file_hash=file_hash)).update(file_hash=file_hash)
 
     def delete_detection(self, file_path: str) -> None:
-        """Delete a detection record."""
-        try:
-            detection = MalwareDetection.objects.get(path=file_path)
-        except MalwareDetection.DoesNotExist:
+        """Delete the detection records for a path."""
+        deleted, _ = MalwareDetection.objects.filter(path=file_path).delete()
+        if not deleted:
             logger.warning("Detection %s not found", file_path)
-            return
-        else:
-            detection.delete()
 
     def failed_analysis(
         self,

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -132,15 +132,13 @@ class JCOPBackend(BaseBackend):
         **kwargs,
     ) -> None:
         """Handle a failed analysis."""
-        try:
-            detection = MalwareDetection.objects.get(path=file_path)
-        except MalwareDetection.DoesNotExist:
+        updated = MalwareDetection.objects.filter(path=file_path).update(
+            status=MalwareDetectionStatus.FAILED,
+            error_code=error_code,
+            error_msg=error_msg,
+        )
+        if not updated:
             logger.warning("Detection %s not found", file_path)
-        else:
-            detection.status = MalwareDetectionStatus.FAILED
-            detection.error_code = error_code
-            detection.error_msg = error_msg
-            detection.save(update_fields=["status", "error_code", "error_msg"])
 
         self.launch_next_analysis()
         self.callback(

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -129,7 +129,7 @@ class JCOPBackend(BaseBackend):
     def failed_analysis(
         self,
         file_path: str,
-        file_hash: str,
+        file_hash: str | None,
         error_code: int,
         error_msg: str,
         status: ReportStatus | None = None,

--- a/src/lasuite/malware_detection/backends/jcop.py
+++ b/src/lasuite/malware_detection/backends/jcop.py
@@ -90,29 +90,31 @@ class JCOPBackend(BaseBackend):
         )
 
     def launch_next_analysis(self) -> None:
-        """Launch the next pending analysis."""
-        if (
-            MalwareDetection.objects.filter(status=MalwareDetectionStatus.PROCESSING).count()
-            >= self.max_processing_files
-        ):
+        """Launch the pending analyses until all processing slots are filled."""
+        free_slots = (
+            self.max_processing_files
+            - MalwareDetection.objects.filter(status=MalwareDetectionStatus.PROCESSING).count()
+        )
+        if free_slots <= 0:
             return
 
         with transaction.atomic():
-            first_pending_detection = (
+            pending_detections = list(
                 MalwareDetection.objects.select_for_update()
                 .filter(status=MalwareDetectionStatus.PENDING)
-                .order_by("created_at")
-                .first()
+                .order_by("created_at")[:free_slots]
             )
-            if first_pending_detection is None:
+            if not pending_detections:
                 return
-            first_pending_detection.status = MalwareDetectionStatus.PROCESSING
-            first_pending_detection.save(update_fields=["status"])
+            MalwareDetection.objects.filter(pk__in=[detection.pk for detection in pending_detections]).update(
+                status=MalwareDetectionStatus.PROCESSING
+            )
 
-        analyse_file_async.delay(
-            first_pending_detection.path,
-            **first_pending_detection.parameters,
-        )
+        for detection in pending_detections:
+            analyse_file_async.delay(
+                detection.path,
+                **detection.parameters,
+            )
 
     def _update_detection_file_hash(self, file_path: str, file_hash: str) -> None:
         """Update the file hash for a detection record."""

--- a/src/lasuite/malware_detection/management/commands/check_analysis_pending.py
+++ b/src/lasuite/malware_detection/management/commands/check_analysis_pending.py
@@ -8,9 +8,11 @@ from lasuite.malware_detection import MalwareDetectionHandler
 class Command(BaseCommand):
     """Management command to check for pending analyses and trigger them if needed."""
 
-    help = "Call, for the active backend, the method launch_next_analysisin order to not have pending analysis blocked."
+    help = (
+        "Call, for the active backend, the method launch_next_analyses in order to not have pending analyses blocked."
+    )
 
     def handle(self, *args, **options):
         """Handle the command."""
         backend = MalwareDetectionHandler()()
-        backend.launch_next_analysis()
+        backend.launch_next_analyses()

--- a/src/lasuite/malware_detection/tasks/jcop.py
+++ b/src/lasuite/malware_detection/tasks/jcop.py
@@ -41,6 +41,7 @@ def analyse_file_async(
         if self.request.retries >= self.max_retries:
             backend.failed_analysis(
                 file_path,
+                file_hash,
                 error_code=MaxRetriesErrorCodes.ANALYSE_FILE,
                 error_msg="Max retries fetching results exceeded",
             )
@@ -51,6 +52,7 @@ def analyse_file_async(
         if self.request.retries >= self.max_retries:
             backend.failed_analysis(
                 file_path,
+                file_hash,
                 error_code=MaxRetriesErrorCodes.ANALYSE_FILE_PENDING,
                 error_msg="Max retries waiting for analysis result exceeded",
             )
@@ -73,6 +75,7 @@ def trigger_new_analysis(
         if self.request.retries >= self.max_retries:
             backend.failed_analysis(
                 file_path,
+                file_hash,
                 error_code=MaxRetriesErrorCodes.TRIGGER_NEW_ANALYSIS,
                 error_msg="Max retries triggering new analysis exceeded",
             )
@@ -83,6 +86,7 @@ def trigger_new_analysis(
         if self.request.retries >= self.max_retries:
             backend.failed_analysis(
                 file_path,
+                file_hash,
                 error_code=MaxRetriesErrorCodes.TRIGGER_NEW_ANALYSIS_TIMEOUT,
                 error_msg="Max retries triggering new analysis exceeded",
             )

--- a/src/lasuite/malware_detection/tasks/jcop.py
+++ b/src/lasuite/malware_detection/tasks/jcop.py
@@ -18,6 +18,7 @@ class MaxRetriesErrorCodes(IntEnum):
     TRIGGER_NEW_ANALYSIS = 9000
     TRIGGER_NEW_ANALYSIS_TIMEOUT = 9001
     ANALYSE_FILE = 9002
+    ANALYSE_FILE_PENDING = 9003
 
 
 @shared_task(
@@ -47,6 +48,13 @@ def analyse_file_async(
         self.retry(exc=exc)
 
     if should_retry:
+        if self.request.retries >= self.max_retries:
+            backend.failed_analysis(
+                file_path,
+                error_code=MaxRetriesErrorCodes.ANALYSE_FILE_PENDING,
+                error_msg="Max retries waiting for analysis result exceeded",
+            )
+            return
         self.retry()
 
 

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -908,6 +908,26 @@ def test_jcop_backend_succeed_analysis_with_duplicate_paths(jcop_backend):
     jcop_callback.assert_called_once_with(file_path, ReportStatus.SAFE, error_info={})
 
 
+def test_jcop_backend_failed_analysis_with_duplicate_paths(jcop_backend):
+    """A failed analysis should complete even when the path has duplicate records."""
+    file_path = "file.txt"
+    factories.MalwareDetectionFactory.create_batch(2, path=file_path, status=MalwareDetectionStatus.PROCESSING)
+
+    jcop_backend.failed_analysis(file_path, "hash123", 5000, "malware detected", ReportStatus.UNSAFE)
+
+    assert (
+        MalwareDetection.objects.filter(
+            path=file_path, status=MalwareDetectionStatus.FAILED, error_code=5000, error_msg="malware detected"
+        ).count()
+        == 2
+    )
+    jcop_callback.assert_called_once_with(
+        file_path,
+        ReportStatus.UNSAFE,
+        error_info={"error": "malware detected", "error_code": 5000, "file_hash": "hash123"},
+    )
+
+
 def test_jcop_backend_reschedule_processing_task(jcop_generate_file_path, jcop_backend):
     """Reschedule the processing task for a malware detection record."""
     file_path, _ = jcop_generate_file_path

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -897,6 +897,17 @@ def test_jcop_backend_delete_non_existing_detection(jcop_backend):
     assert MalwareDetection.objects.count() == 0
 
 
+def test_jcop_backend_succeed_analysis_with_duplicate_paths(jcop_backend):
+    """A successful analysis should complete even when the path has duplicate records."""
+    file_path = "file.txt"
+    factories.MalwareDetectionFactory.create_batch(2, path=file_path, status=MalwareDetectionStatus.PROCESSING)
+
+    jcop_backend.succeed_analysis(file_path)
+
+    assert not MalwareDetection.objects.filter(path=file_path).exists()
+    jcop_callback.assert_called_once_with(file_path, ReportStatus.SAFE, error_info={})
+
+
 def test_jcop_backend_reschedule_processing_task(jcop_generate_file_path, jcop_backend):
     """Reschedule the processing task for a malware detection record."""
     file_path, _ = jcop_generate_file_path

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -885,10 +885,24 @@ def test_jcop_backend_launch_next_analysis(jcop_generate_file_path, jcop_backend
         mock.patch.object(analyse_file_async, "delay") as analyse_file_async_mock,
     ):
         jcop_backend.launch_next_analysis()
-        analyse_file_async_mock.assert_called_once_with(
+        assert analyse_file_async_mock.call_count == 11
+        assert analyse_file_async_mock.call_args_list[0] == mock.call(
             file_path,
             foo="bar",
         )
+
+
+def test_jcop_backend_launch_next_analysis_fills_all_free_slots(jcop_backend_parameters):
+    """launch_next_analysis should dispatch pending analyses until all slots are filled."""
+    backend = jcop.JCOPBackend(**jcop_backend_parameters, max_processing_files=3)
+    factories.MalwareDetectionFactory.create_batch(5, status=MalwareDetectionStatus.PENDING)
+
+    with mock.patch.object(analyse_file_async, "delay") as analyse_file_async_mock:
+        backend.launch_next_analysis()
+
+    assert analyse_file_async_mock.call_count == 3
+    assert MalwareDetection.objects.filter(status=MalwareDetectionStatus.PROCESSING).count() == 3
+    assert MalwareDetection.objects.filter(status=MalwareDetectionStatus.PENDING).count() == 2
 
 
 def test_jcop_backend_launch_next_analysis_no_pending_detection(jcop_backend):

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -130,6 +130,28 @@ def test_jcop_backend_file_does_not_exists(jcop_backend):
         jcop_backend.analyse_file("file.txt")
 
 
+def test_jcop_backend_analyse_file_twice_does_not_stack_duplicates(jcop_generate_file_path, jcop_backend):
+    """Calling analyse_file twice on the same path should not create a duplicate record."""
+    with mock.patch.object(analyse_file_async, "delay"):
+        file_path, _ = jcop_generate_file_path
+        jcop_backend.analyse_file(file_path)
+        jcop_backend.analyse_file(file_path)
+
+    assert MalwareDetection.objects.filter(path=file_path).count() == 1
+
+
+def test_jcop_backend_analyse_file_after_failed_creates_new_record(jcop_generate_file_path, jcop_backend):
+    """A FAILED record should not prevent a new analysis on the same path."""
+    file_path, _ = jcop_generate_file_path
+    factories.MalwareDetectionFactory(path=file_path, status=MalwareDetectionStatus.FAILED)
+
+    with mock.patch.object(analyse_file_async, "delay"):
+        jcop_backend.analyse_file(file_path)
+
+    assert MalwareDetection.objects.filter(path=file_path, status=MalwareDetectionStatus.FAILED).count() == 1
+    assert MalwareDetection.objects.filter(path=file_path).exclude(status=MalwareDetectionStatus.FAILED).count() == 1
+
+
 @responses.activate
 @pytest.mark.parametrize("used_kwargs", [{}, {"foo": "bar"}])
 @pytest.mark.parametrize("with_file_hash", [True, False])

--- a/tests/malware_detection/backends/test_jcop_backend.py
+++ b/tests/malware_detection/backends/test_jcop_backend.py
@@ -873,8 +873,8 @@ def test_jcop_backend_trigger_new_analysis_unknown_status_complete_flow(
     assert next_record.status == MalwareDetectionStatus.PROCESSING
 
 
-def test_jcop_backend_launch_next_analysis(jcop_generate_file_path, jcop_backend):
-    """Launch a new analysis when calling launch_next_analysis."""
+def test_jcop_backend_launch_next_analyses(jcop_generate_file_path, jcop_backend):
+    """Launch all the pending analyses when calling launch_next_analyses."""
     file_path, _ = jcop_generate_file_path
     factories.MalwareDetectionFactory(status=MalwareDetectionStatus.PENDING, path=file_path, parameters={"foo": "bar"})
 
@@ -884,7 +884,7 @@ def test_jcop_backend_launch_next_analysis(jcop_generate_file_path, jcop_backend
     with (
         mock.patch.object(analyse_file_async, "delay") as analyse_file_async_mock,
     ):
-        jcop_backend.launch_next_analysis()
+        jcop_backend.launch_next_analyses()
         assert analyse_file_async_mock.call_count == 11
         assert analyse_file_async_mock.call_args_list[0] == mock.call(
             file_path,
@@ -892,25 +892,25 @@ def test_jcop_backend_launch_next_analysis(jcop_generate_file_path, jcop_backend
         )
 
 
-def test_jcop_backend_launch_next_analysis_fills_all_free_slots(jcop_backend_parameters):
-    """launch_next_analysis should dispatch pending analyses until all slots are filled."""
+def test_jcop_backend_launch_next_analyses_fills_all_free_slots(jcop_backend_parameters):
+    """launch_next_analyses should dispatch pending analyses until all slots are filled."""
     backend = jcop.JCOPBackend(**jcop_backend_parameters, max_processing_files=3)
     factories.MalwareDetectionFactory.create_batch(5, status=MalwareDetectionStatus.PENDING)
 
     with mock.patch.object(analyse_file_async, "delay") as analyse_file_async_mock:
-        backend.launch_next_analysis()
+        backend.launch_next_analyses()
 
     assert analyse_file_async_mock.call_count == 3
     assert MalwareDetection.objects.filter(status=MalwareDetectionStatus.PROCESSING).count() == 3
     assert MalwareDetection.objects.filter(status=MalwareDetectionStatus.PENDING).count() == 2
 
 
-def test_jcop_backend_launch_next_analysis_no_pending_detection(jcop_backend):
+def test_jcop_backend_launch_next_analyses_no_pending_detection(jcop_backend):
     """When there is no pending detection, the method does nothing."""
     with (
         mock.patch.object(analyse_file_async, "delay") as analyse_file_async_mock,
     ):
-        jcop_backend.launch_next_analysis()
+        jcop_backend.launch_next_analyses()
         analyse_file_async_mock.assert_not_called()
 
 

--- a/tests/malware_detection/tasks/test_jcop_tasks.py
+++ b/tests/malware_detection/tasks/test_jcop_tasks.py
@@ -46,6 +46,26 @@ def test_analyse_file_async_retry(mock_backend):
     backend.failed_analysis.assert_not_called()
 
 
+def test_analyse_file_async_retry_max_retries(mock_backend):
+    """Test analyse_file_async with analysis still pending and max retries reached."""
+    backend, handler = mock_backend
+    backend.check_analysis.return_value = True  # Retry needed
+    backend.failed_analysis = mock.MagicMock()
+
+    with (
+        mock.patch("lasuite.malware_detection.tasks.jcop.MalwareDetectionHandler", return_value=handler),
+        mock.patch.object(analyse_file_async, "max_retries", 0),
+    ):
+        analyse_file_async("file.txt", file_hash="hash123")
+
+    backend.check_analysis.assert_called_once_with("file.txt", file_hash="hash123")
+    backend.failed_analysis.assert_called_once_with(
+        "file.txt",
+        error_code=MaxRetriesErrorCodes.ANALYSE_FILE_PENDING,
+        error_msg="Max retries waiting for analysis result exceeded",
+    )
+
+
 def test_analyse_file_async_request_exception_retry(mock_backend):
     """Test analyse_file_async with request exception and retry."""
     backend, handler = mock_backend

--- a/tests/malware_detection/tasks/test_jcop_tasks.py
+++ b/tests/malware_detection/tasks/test_jcop_tasks.py
@@ -6,8 +6,11 @@ import pytest
 import requests
 from celery.exceptions import Retry
 
+from lasuite.malware_detection.backends.jcop import JCOPBackend
 from lasuite.malware_detection.exceptions import MalwareDetectionInvalidAuthenticationError
 from lasuite.malware_detection.tasks.jcop import MaxRetriesErrorCodes, analyse_file_async, trigger_new_analysis
+
+jcop_callback = mock.MagicMock()
 
 
 @pytest.fixture
@@ -61,6 +64,7 @@ def test_analyse_file_async_retry_max_retries(mock_backend):
     backend.check_analysis.assert_called_once_with("file.txt", file_hash="hash123")
     backend.failed_analysis.assert_called_once_with(
         "file.txt",
+        "hash123",
         error_code=MaxRetriesErrorCodes.ANALYSE_FILE_PENDING,
         error_msg="Max retries waiting for analysis result exceeded",
     )
@@ -93,7 +97,10 @@ def test_analyse_file_async_request_exception_max_retries(mock_backend):
 
     backend.check_analysis.assert_called_once_with("file.txt", file_hash=None)
     backend.failed_analysis.assert_called_once_with(
-        "file.txt", error_code=MaxRetriesErrorCodes.ANALYSE_FILE, error_msg="Max retries fetching results exceeded"
+        "file.txt",
+        None,
+        error_code=MaxRetriesErrorCodes.ANALYSE_FILE,
+        error_msg="Max retries fetching results exceeded",
     )
 
 
@@ -110,6 +117,29 @@ def test_analyse_file_async_with_auth_error_no_retry(mock_backend):
 
     backend.check_analysis.assert_called_once_with("file.txt", file_hash=None)
     backend.failed_analysis.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_analyse_file_async_max_retries_real_backend_signature():
+    """Test the max-retries guard against the real backend failed_analysis signature."""
+    jcop_callback.reset_mock()
+    backend = JCOPBackend(
+        base_url="https://malware_detection.tld/api/v1",
+        api_key="xxxx",
+        callback_path="tests.malware_detection.tasks.test_jcop_tasks.jcop_callback",
+    )
+    handler = mock.MagicMock()
+    handler.return_value = backend
+
+    with (
+        mock.patch("lasuite.malware_detection.tasks.jcop.MalwareDetectionHandler", return_value=handler),
+        mock.patch.object(backend, "check_analysis", side_effect=requests.exceptions.RequestException("Connection")),
+        mock.patch.object(analyse_file_async, "max_retries", 0),
+    ):
+        analyse_file_async("file.txt", file_hash="hash123")
+
+    jcop_callback.assert_called_once()
+    assert jcop_callback.call_args.kwargs["error_info"]["error_code"] == MaxRetriesErrorCodes.ANALYSE_FILE
 
 
 def test_trigger_new_analysis_success(mock_backend):
@@ -164,6 +194,7 @@ def test_trigger_new_analysis_request_exception_max_retries(mock_backend):
     backend.trigger_new_analysis.assert_called_once_with("file.txt", "file_hash")
     backend.failed_analysis.assert_called_once_with(
         "file.txt",
+        "file_hash",
         error_code=MaxRetriesErrorCodes.TRIGGER_NEW_ANALYSIS,
         error_msg="Max retries triggering new analysis exceeded",
     )
@@ -181,6 +212,7 @@ def test_trigger_new_analysis_timeout_max_retries(mock_backend):
     backend.trigger_new_analysis.assert_called_once_with("file.txt", "file_hash")
     backend.failed_analysis.assert_called_once_with(
         "file.txt",
+        "file_hash",
         error_code=MaxRetriesErrorCodes.TRIGGER_NEW_ANALYSIS_TIMEOUT,
         error_msg="Max retries triggering new analysis exceeded",
     )

--- a/tests/malware_detection/test_check_analysis_pending_command.py
+++ b/tests/malware_detection/test_check_analysis_pending_command.py
@@ -7,15 +7,15 @@ from django.core.management import call_command
 from lasuite.malware_detection.backends.base import BaseBackend
 from lasuite.malware_detection.models import MalwareDetection
 
-mock_launch_next_analysis = mock.MagicMock()
+mock_launch_next_analyses = mock.MagicMock()
 
 
 class TestBackend(BaseBackend):
     """Test backend."""
 
-    def launch_next_analysis(self) -> None:
-        """Launch the next analysis."""
-        mock_launch_next_analysis()
+    def launch_next_analyses(self) -> None:
+        """Launch the pending analyses."""
+        mock_launch_next_analyses()
 
     def analyse_file(self, file_path: str, **kwargs) -> None:
         """Analyse a file."""
@@ -35,4 +35,4 @@ def test_check_analysis_pending_command(settings):
 
     call_command("check_analysis_pending")
 
-    mock_launch_next_analysis.assert_called_once()
+    mock_launch_next_analyses.assert_called_once()

--- a/tests/malware_detection/test_malware_detection_reschedule_processing_analysis_command.py
+++ b/tests/malware_detection/test_malware_detection_reschedule_processing_analysis_command.py
@@ -17,8 +17,8 @@ pytestmark = pytest.mark.django_db
 class TestBackend(BaseBackend):
     """Test backend."""
 
-    def launch_next_analysis(self) -> None:
-        """Launch the next analysis."""
+    def launch_next_analyses(self) -> None:
+        """Launch the pending analyses."""
 
     def analyse_file(self, file_path: str, **kwargs) -> None:
         """Analyse a file."""


### PR DESCRIPTION
## Purpose

The JCOP backend leaks `max_processing_files` slots: a record stuck in
PROCESSING is never reclaimed, and once enough accumulate the analysis
queue deadlocks — every new file stays PENDING forever. This happened
in production on a Drive instance.

## Proposal

- [x] Mark the detection FAILED when polling retries are exhausted in
  `analyse_file_async`, instead of raising an unhandled
  `MaxRetriesExceededError`
- [x] Pass the missing `file_hash` argument to `failed_analysis()` in
  the task max-retries guards (they raised `TypeError`)
- [x] Tolerate duplicate paths in `delete_detection` and
  `failed_analysis` (`MultipleObjectsReturned` since 0.0.28 removed the
  unicity constraint on `path`)
- [x] Stop stacking duplicate detections in `analyse_file` when the path
  already has a PENDING or PROCESSING record
- [x] Fill all free slots in `launch_next_analysis`, instead of one
  analysis per invocation
