### PR TITLE
🔖(patch) bump release to 0.0.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.0.29] - 2026-08-25
+
 ### Changed
 
 - ✨(malware) fill all free slots in launch_next_analysis
@@ -239,8 +241,9 @@ and this project adheres to
 - ✨(oidc) add the authentication backends #2
 - ✨(oidc) add refresh token tools #3
 
-[unreleased]: https://github.com/suitenumerique/django-lasuite/compare/v0.0.28...main
-[0.0.28]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.27
+[unreleased]: https://github.com/suitenumerique/django-lasuite/compare/v0.0.29...main
+[0.0.29]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.29
+[0.0.28]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.28
 [0.0.27]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.27
 [0.0.26]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.26
 [0.0.25]: https://github.com/suitenumerique/django-lasuite/releases/v0.0.25

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "django-lasuite"
-version = "0.0.28"
+version = "0.0.29"
 description = "Django La Suite - A Django library"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Purpose

Release 0.0.29.

### Changed

- ✨(malware) fill all free slots in launch_next_analysis
- ♻(malware) rename launch_next_analysis to launch_next_analyses

### Fixed

- 🐛(malware) handle polling retry exhaustion in analyse_file_async
- 🐛(malware) pass file_hash to failed_analysis in retry guards
- 🐛(malware) make delete_detection tolerant to duplicate paths
- 🐛(malware) make failed_analysis tolerant to duplicate paths
- 🐛(malware) stop stacking duplicate detections in analyse_file

